### PR TITLE
Add -f flag to git push after rebase

### DIFF
--- a/docs/code.md
+++ b/docs/code.md
@@ -224,7 +224,8 @@ back to where you started.
 
  	Make sure your message includes your signature.
 
-8. Push any changes to your fork on GitHub.
+8. Push any changes to your fork on GitHub, using the `-f` option to
+force the previous change to be overwritten.
 
-        $ git push origin my-keen-feature
+        $ git push -f origin my-keen-feature
 


### PR DESCRIPTION
The `-f` flag is necessary when you push after a rebase.

Identical to https://github.com/docker/docker/pull/12366