### PR TITLE
Fix for #24 missing reference to 'Windows' platform on the "Organize the issues" page.

### DIFF
--- a/docs/ways/issues.md
+++ b/docs/ways/issues.md
@@ -51,7 +51,7 @@ notification go to your GitHub or email inbox. Some of repositories you can watc
     </tr>
     <tr>
         <td class="tg-031e"><a href="https://github.com/kitematic/kitematic" target="_blank">kitematic/kitematic</a></td>
-        <td class="tg-031e">Kitematic is a simple application for managing Docker containers on Mac OS X.</td>
+        <td class="tg-031e">Kitematic is a simple application for managing Docker containers on Mac OS X and Windows.</td>
     </tr>
     </tr>
     <tr>


### PR DESCRIPTION
Fixes #24 missing reference to 'Windows' platform on the "Organize the issues" page.

Signed-off-by: Anil Belur <askb23@gmail.com>