### PR TITLE
Some broken links due to pages moving.

### DIFF
--- a/docs/project/set-up-dev-env.md
+++ b/docs/project/set-up-dev-env.md
@@ -22,7 +22,7 @@ You use the `docker` repository and its `Dockerfile` to create a Docker image,
 run a Docker container, and develop code in the container. Docker itself builds,
 tests, and releases new Docker versions using this container.
 
-If you followed the procedures that <a href="/engine/project/set-up-git" target="_blank">
+If you followed the procedures that <a href="/opensource/project/set-up-git/" target="_blank">
 set up Git for contributing</a>, you should have a fork of the `docker/docker`
 repository. You also created a branch called `dry-run-test`. In this section,
 you continue working with your fork on this branch.
@@ -105,7 +105,7 @@ environment.
         $ cd ~/repos/docker-fork
 
 	If you are following along with this guide, you created a `dry-run-test`
-	branch when you <a href="/engine/project/set-up-git" target="_blank"> set up Git for
+	branch when you <a href="/opensource/project/set-up-git/" target="_blank"> set up Git for
 	contributing</a>.
 
 4. Ensure you are on your `dry-run-test` branch.

--- a/docs/workflow/create-pr.md
+++ b/docs/workflow/create-pr.md
@@ -84,7 +84,7 @@ Always rebase and squash your commits before making a pull request.
 
         $ git commit -s
 
-    Make sure your message includes <a href="../set-up-git" target="_blank">your signature</a>.
+    Make sure your message includes <a href="/opensource/project/set-up-git/" target="_blank">your signature</a>.
 
 7. Force push any changes to your fork on GitHub.
 

--- a/docs/workflow/work-issue.md
+++ b/docs/workflow/work-issue.md
@@ -28,7 +28,7 @@ Follow this workflow as you work:
 
     If you are changing code, review the <a href="../coding-style"
     target="_blank">coding style guide</a>. Changing documentation? Review the
-    <a href="../doc-style" target="_blank">documentation style guide</a>.
+    <a href="/opensource/doc-style/" target="_blank">documentation style guide</a>.
 
 2. Make changes in your feature branch.
 
@@ -39,7 +39,7 @@ Follow this workflow as you work:
 
     Make sure you don't change files in the `vendor` directory and its
     subdirectories; they contain third-party dependency code. Review <a
-    href="../set-up-dev-env" target="_blank">if you forgot the details of
+    href="/opensource/project/set-up-dev-env/" target="_blank">if you forgot the details of
     working with a container</a>.
 
 
@@ -48,7 +48,7 @@ Follow this workflow as you work:
     If you have followed along with the guide, you know the `make test` target
     runs the entire test suite and `make docs` builds the documentation. If you
     forgot the other test targets, see the documentation for <a
-    href="../test-and-docs" target="_blank">testing both code and
+    href="/opensource/project/test-and-docs/" target="_blank">testing both code and
     documentation</a>.  
 
 4. For code changes, add unit tests if appropriate.
@@ -187,7 +187,7 @@ You should pull and rebase frequently as you work.
 
         $ git commit -s
 
-    Make sure your message includes <a href="../set-up-git" target="_blank">your signature</a>.
+    Make sure your message includes <a href="/opensource/project/set-up-git/" target="_blank">your signature</a>.
 
 7. Force push any changes to your fork on GitHub.
 


### PR DESCRIPTION
Due to the way s3 redirects work, urls need to have a '/' at the end for the redirect to work :(

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

some time in the future, we should go through and convert these into markdown links, so they can be tested and validated at the source.