### PR TITLE
Updated applicable links to markdown

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -70,8 +70,8 @@ revert would remove all traces of the feature or fix.
 
 ## How should I comment my code?
 
-The Go blog wrote about code comments, it is <a href="http://goo.gl/fXCRu"
-target="_blank">a single page explanation</a>. A summary follows:
+The Go blog wrote about code comments, it is
+[a single page explanation](https://goo.gl/fXCRu). A summary follows:
 
 - Comments begin with two forward `//` slashes.
 - To document a type, variable, constant, function, or even a package, write a

--- a/docs/code.md
+++ b/docs/code.md
@@ -12,7 +12,7 @@ weight=-3
 # Quickstart code or doc contribution
 
 If you'd like to improve the code of any of Docker's projects, we would love to
-have your contributions. All of our projects' code <a href="https://github.com/docker" target="_blank">repositories are on GitHub</a>.
+have your contributions. All of our projects' code [repositories are on GitHub](https://github.com/docker).
 
 If you want to contribute to the `docker/docker` repository you should be
 familiar with or a invested in learning Go or the Markdown language.  If you
@@ -26,48 +26,40 @@ If you are an experienced open source contributor you may be familiar with this
 workflow. If you are new or just need reminders, the steps below link to more
 detailed documentation in Docker's project contributors guide.
 
-1. <a href="http://docs.docker.com/project/software-required/"
-target="_blank">Get the software</a> you need.
+1. [Get the software](project/software-required.md) you need.
 
 	This explains how to install a couple of tools used in our development
 	environment.  What you need (or don't need) might surprise you.
 
-2. <a href="http://docs.docker.com/project/set-up-git/"
-target="_blank">Configure Git and fork the repo</a>.
+2. [Configure Git and fork the repo](project/set-up-git.md).
 
 	Your Git configuration can make it easier for you to contribute.
 	Configuration is especially key if are new to contributing or to Docker.
 
-3. <a href="http://docs.docker.com/project/set-up-dev-env/"
-target="_blank">Learn to work with the Docker development container</a>.
+3. [Learn to work with the Docker development container](project/set-up-dev-env.md).
 
 	Docker developers run `docker` in `docker`.  If you are a geek,
 	this is a pretty cool experience.
-4. <a href="http://docs.docker.com/project/find-an-issue/"
-target="_blank">Claim an issue</a> to work on.
 
-	We created a filter listing <a href="http://goo.gl/Hsp2mk" target="_blank">all open
-	and unclaimed issues</a> for Docker.
+4. [Claim an issue](workflow/find-an-issue.md) to work on.
 
-5. <a
-href="http://docs.docker.com/project/work-issue/" target="_blank">Work on the
-issue</a>.
+	We created a filter listing 
+	[all open and unclaimed issues](https://goo.gl/Hsp2mk) for Docker.
+
+5. [Work on the issue](workflow/work-issue.md).
 
 	If you change or add code or docs to a project, you should test your changes
-	as you work. This page explains <a
-	href="http://docs.docker.com/project/test-and-docs/" target="_blank">how to
-	test in our development environment</a>.  
+	as you work. This page explains 
+	[how to	test in our development environment](project/test-and-docs.md).  
 
 	Also, remember to always **sign your commits** as you work! To sign your
 	commits, include the `-s` flag in your commit like this:
 
 		$ git commit -s -m "Add commit with signature example"
 
-	If you don't sign <a href="https://twitter.com/gordontheturtle"
-	target="_blank">Gordon</a> will get you!
+	If you don't sign [Gordon](https://twitter.com/gordontheturtle) will get you!
 
-6. <a href="http://docs.docker.com/project/create-pr/" target="_blank">Create a
-pull request</a>.
+6. [Create a pull request](workflow/create-pr.md).
 
 	If you make a change to fix an issue, add reference to the issue in the pull
 	request. Here is an example of a perfect pull request with a good description,
@@ -79,6 +71,5 @@ pull request</a>.
 	needs](#what-is-the-pre-pull-request-checklist).
 
 
-7. <a href="http://docs.docker.com/project/review-pr/"
-target="_blank">Participate in the pull request review</a> till a successful
-merge.
+7. [Participate in the pull request review](workflow/review-pr.md) 
+till a successful merge.

--- a/docs/doc-style.md
+++ b/docs/doc-style.md
@@ -15,9 +15,9 @@ weight=4
 
 Over time, different publishing communities have written standards for the style
 and grammar they prefer in their publications. These standards are called
-[style guides](http://en.wikipedia.org/wiki/Style_guide). Generally, Docker’s
+[style guides](https://en.wikipedia.org/wiki/Style_guide). Generally, Docker’s
 documentation uses the standards described in the
-[Associated Press's (AP) style guide](http://en.wikipedia.org/wiki/AP_Stylebook).
+[Associated Press's (AP) style guide](https://en.wikipedia.org/wiki/AP_Stylebook).
 If a question about syntactical, grammatical, or lexical practice comes up,
 refer to the AP guide first. If you don’t have a copy of (or online subscription
 to) the AP guide, you can almost always find an answer to a specific question by
@@ -63,7 +63,7 @@ technical writing."
 
 One exception to the "don’t write directly for ESL" rule is to avoid the use of
 metaphor or other
-[figurative language](http://en.wikipedia.org/wiki/Literal_and_figurative_language) to
+[figurative language](https://en.wikipedia.org/wiki/Literal_and_figurative_language) to
 describe things. There are too many cultural and social issues that can prevent
 a reader from correctly interpreting a metaphor.
 
@@ -196,7 +196,7 @@ verb (two words), as in "Log in to the terminal".
 ### Oxford comma
 
 One way in which we differ from AP style is that Docker’s docs use the [Oxford
-comma](http://en.wikipedia.org/wiki/Serial_comma) in all cases. That’s our
+comma](https://en.wikipedia.org/wiki/Serial_comma) in all cases. That’s our
 position on this controversial topic, we won't change our mind, and that’s that!
 
 ### Code and UI text styling
@@ -249,7 +249,7 @@ potential problems in communication or presentation.
 ### Commit messages
 
 In order to write clear, useful commit messages, please follow these
-[recommendations](http://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message).
+[recommendations](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message).
 
 ## Links
 

--- a/docs/get-help.md
+++ b/docs/get-help.md
@@ -61,7 +61,7 @@ community members and developers.
     <td>Stack Overflow</td>
     <td>
       Stack Overflow has over 7000K Docker questions listed. We regularly
-      monitor <a href="http://stackoverflow.com/search?tab=newest&q=docker" target="_blank">Docker questions</a>
+      monitor <a href="https://stackoverflow.com/search?tab=newest&q=docker" target="_blank">Docker questions</a>
       and so do many other knowledgeable Docker users.
     </td>
   </tr>
@@ -80,7 +80,7 @@ platforms.
 Using Webchat from Freenode.net is a quick and easy way to get chatting. To
 register:
 
-1. In your browser open <a href="https://webchat.freenode.net" target="_blank">https://webchat.freenode.net</a>
+1. In your browser open [https://webchat.freenode.net](https://webchat.freenode.net)
 
     ![Login to webchat screen](images/irc_connect.png)
 
@@ -144,7 +144,7 @@ a Freemium product, meaning the free version is limited and you can pay for more
 features. To use IRCCloud:
 
 1. Select the following link:
-  <a href="https://www.irccloud.com/invite?channel=%23docker&amp;hostname=chat.freenode.net&amp;port=6697" target="_blank">Join the #docker channel on chat.freenode.net</a>
+  [Join the #docker channel on chat.freenode.net](https://www.irccloud.com/invite?channel=%23docker&amp;hostname=chat.freenode.net&amp;port=6697).
 
     The following web page is displayed in your browser:
 
@@ -194,9 +194,8 @@ on the command line using this command:
 
       /msg NickServ identify <password>
 
-With Webchat if you forget or lose your password see <a
-href="https://freenode.net/faq.shtml#sendpass" target="_blank">the FAQ on
-freenode.net</a> to learn how to recover it.
+With Webchat if you forget or lose your password see 
+[the FAQ on freenode.net](https://freenode.net/faq.shtml#sendpass) to learn how to recover it.
 
 ### Join a Docker Channel
 
@@ -219,6 +218,5 @@ To ask questions to the group just type messages in the command line bar:
 
 This quickstart was meant to get you up and into IRC very quickly. If you find
 IRC useful there is more to learn. Drupal, another open source project,
-has <a href="https://www.drupal.org/irc/setting-up" target="_blank">
-written some documentation about using IRC</a> for their project
-(thanks Drupal!).
+has [written some documentation about using IRC](https://www.drupal.org/irc/setting-up) 
+for their project (thanks Drupal!).

--- a/docs/project/set-up-dev-env.md
+++ b/docs/project/set-up-dev-env.md
@@ -22,8 +22,8 @@ You use the `docker` repository and its `Dockerfile` to create a Docker image,
 run a Docker container, and develop code in the container. Docker itself builds,
 tests, and releases new Docker versions using this container.
 
-If you followed the procedures that <a href="/opensource/project/set-up-git/" target="_blank">
-set up Git for contributing</a>, you should have a fork of the `docker/docker`
+If you followed the procedures that [set up Git for contributing](/opensource/project/set-up-git.md),
+ you should have a fork of the `docker/docker`
 repository. You also created a branch called `dry-run-test`. In this section,
 you continue working with your fork on this branch.
 
@@ -105,8 +105,7 @@ environment.
         $ cd ~/repos/docker-fork
 
 	If you are following along with this guide, you created a `dry-run-test`
-	branch when you <a href="/opensource/project/set-up-git/" target="_blank"> set up Git for
-	contributing</a>.
+	branch when you [set up Git for contributing](/opensource/project/set-up-git.md).
 
 4. Ensure you are on your `dry-run-test` branch.
 

--- a/docs/project/set-up-git.md
+++ b/docs/project/set-up-git.md
@@ -30,8 +30,7 @@ To fork and clone Docker:
 
 1. Open a browser and log into GitHub with your account.
 
-2. Go to the <a href="https://github.com/docker/docker"
-target="_blank">docker/docker repository</a>.
+2. Go to the [docker/docker repository](https://github.com/docker/docker).
 
 3. Click the "Fork" button in the upper right corner of the GitHub interface.
 
@@ -85,7 +84,7 @@ target="_blank">docker/docker repository</a>.
 ##  Set your signature and an upstream remote
 
 When you contribute to Docker, you must certify you agree with the
-<a href="http://developercertificate.org/" target="_blank">Developer Certificate of Origin</a>.
+[Developer Certificate of Origin](http://developercertificate.org/).
 You indicate your agreement by signing your `git` commits like this:
 
     Signed-off-by: Pat Smith <pat.smith@email.com>

--- a/docs/project/software-req-win.md
+++ b/docs/project/software-req-win.md
@@ -28,8 +28,7 @@ instructions.
 
 ### Get a GitHub account
 
-To contribute to the Docker project, you will need a <a
-href="https://github.com" target="_blank">GitHub account</a>. A free account is
+To contribute to the Docker project, you will need a [GitHub account](https://github.com). A free account is
 fine. All the Docker project repositories are public and visible to everyone.
 
 You should also have some experience using both the GitHub application and `git`

--- a/docs/project/software-required.md
+++ b/docs/project/software-required.md
@@ -25,8 +25,7 @@ provides it for you. You'll learn more about the development environment later.
 
 ### Get a GitHub account
 
-To contribute to the Docker project, you will need a <a
-href="https://github.com" target="_blank">GitHub account</a>. A free account is
+To contribute to the Docker project, you will need a [GitHub account](https://github.com). A free account is
 fine. All the Docker project repositories are public and visible to everyone.
 
 You should also have some experience using both the GitHub application and `git`
@@ -56,7 +55,7 @@ depending on your OS.
 ### Install or upgrade Docker
 
 If you haven't already, install the Docker software using the
-<a href="/engine/installation" target="_blank">instructions for your operating system</a>.
+[instructions for your operating system](https://docs.docker.com/engine/installation/).
 If you have an existing installation, check your version and make sure you have
 the latest Docker.
 

--- a/docs/project/test-and-docs.md
+++ b/docs/project/test-and-docs.md
@@ -31,10 +31,9 @@ branches.
 Docker tests use the Go language's test framework. In this framework, files
 whose names end in `_test.go` contain test code; you'll find test files like
 this throughout the Docker repo. Use these files for inspiration when writing
-your own tests. For information on Go's test framework, see <a
-href="http://golang.org/pkg/testing/" target="_blank">Go's testing package
-documentation</a> and the <a href="http://golang.org/cmd/go/#hdr-Test_packages"
-target="_blank">go test help</a>.
+your own tests. For information on Go's test framework, see 
+[Go's testing package documentation](https://golang.org/pkg/testing/) 
+and the [go test help](https://golang.org/cmd/go/#hdr-Test_packages).
 
 You are responsible for _unit testing_ your contribution when you add new or
 change existing Docker code. A unit test is a piece of code that invokes a
@@ -267,14 +266,12 @@ make any changes just run these commands again.
 ## Build and test the documentation
 
 The Docker documentation source files are under `docs`. The content is
-written using extended Markdown. We use the static generator <a
-href="http://www.mkdocs.org/" target="_blank">MkDocs</a> to build Docker's
-documentation. Of course, you don't need to install this generator
+written using extended Markdown. We use the static generator [MkDocs](http://www.mkdocs.org/) 
+to build Docker's documentation. Of course, you don't need to install this generator
 to build the documentation, it is included with container.
 
 You should always check your documentation for grammar and spelling. The best
-way to do this is with <a href="http://www.hemingwayapp.com/"
-target="_blank">an online grammar checker</a>.
+way to do this is with [an online grammar checker](http://www.hemingwayapp.com/).
 
 When you change a documentation source file, you should test your change
 locally to make sure your content is there and any links work correctly. You

--- a/docs/project/who-written-for.md
+++ b/docs/project/who-written-for.md
@@ -12,9 +12,9 @@ parent = "smn_engine_contrib"
 
 This section of the documentation contains a guide for Docker users who want to
 contribute code or documentation to the Docker Engine project. As a community, we
-share rules of behavior and interaction. Make sure you are familiar with the <a
-href="https://github.com/docker/docker/blob/master/CONTRIBUTING.md#docker-community-guidelines"
-target="_blank">community guidelines</a> before continuing.
+share rules of behavior and interaction. Make sure you are familiar with the 
+[community guidelines](https://github.com/docker/docker/blob/master/
+CONTRIBUTING.md#docker-community-guidelines) before continuing.
 
 ## Where and what you can contribute
 

--- a/docs/ways/community.md
+++ b/docs/ways/community.md
@@ -19,8 +19,8 @@ contribute mentoring if you have good knowledge of:
 * using Docker in some particular domain (for example, testing or deployment)
 * using Git, Go, GitHub, IRC, or other common tools
 
-Also, choose mentoring if you like to be happy. Studies show that <a
-href="http://goo.gl/HSz8UT" target="_blank">helping others</a> is a great way to
+Also, choose mentoring if you like to be happy. Studies show that 
+[helping others](https://goo.gl/HSz8UT)is a great way to
 boost your own well being.
 
 
@@ -28,14 +28,12 @@ boost your own well being.
 
 Docker users are people using Docker in their daily work. To help Docker users, visit:
 
-* the <a href="https://groups.google.com/forum/#!forum/docker-user"
-target="_blank">Docker-user</a> Google group
+* the [Docker-user](https://groups.google.com/forum/#!forum/docker-user) Google group
 * the `#docker` channel on Freenode IRC
-*  <a href="http://stackoverflow.com/search?tab=newest&q=docker"
-target="_blank">StackOverflow</a>
+* [StackOverflow](https://stackoverflow.com/search?tab=newest&q=docker)
 
-You can also check the <a href="http://goo.gl/Kv8EdU" target="_blank">list of
-open user questions</a> on the Docker project.
+You can also check the [list of open user questions](https://goo.gl/Kv8EdU) 
+on the Docker project.
 
 
 ## Docker contributors
@@ -44,10 +42,9 @@ Docker contributors are people like you contributing to Docker open source.
 Contributors may need help with IRC, Go programming, Markdown, or with other
 aspects of contributing. To help Docker contributors:
 
-* the <a href="https://gitter.im/docker/docker" target="_blank">Docker Gitter IM
-</a> room
-* the <a href="https://groups.google.com/forum/#!forum/docker-dev"
-target="_blank">docker-dev</a>  Google group
-* the <a href="https://dev.dockerproject.com"
-target="_blank">dev.dockerproject.com</a> on Discourse
+* the [Docker Gitter IM](https://gitter.im/docker/docker) 
+room
+* the [docker-dev](https://groups.google.com/forum/#!forum/docker-dev) 
+Google group
+* the [dev.dockerproject.com](https://dev.dockerproject.com) on Discourse
 * the `#docker-dev` channel on Freenode IRC

--- a/docs/ways/issues.md
+++ b/docs/ways/issues.md
@@ -32,7 +32,7 @@ Docker users and contributors create new issues if they want to:
 
 Follow these steps:
 
-1. Sign up for a <a href="https://github.com" target="_blank">Github account</a>.
+1. Sign up for a [Github account](https://github.com).
 
 2. Visit a Docker repository and press the **Watch** button.
 
@@ -65,19 +65,16 @@ notification go to your GitHub or email inbox. Some of repositories you can watc
 </table>
 
 
-See <a href="https://github.com/docker" target="_blank">the complete list of
-Docker repositories</a> on GitHub.
+See [the complete list of Docker repositories](https://github.com/docker) on GitHub.
 
-3. Choose an issue from the <a
-href="https://github.com/docker/docker/issues?q=is%3Aopen+is%3Aissue+-label%
-3Akind%2Fproposal+-label%3Akind%2Fenhancement+-label%3Akind%2Fbug+-label%3Akind%
+3. Choose an issue from the [list of untriaged issues](https://github.com/docker/docker/issues?q=is%3Aopen+is%3Aissue+-
+label%3Akind%2Fproposal+-label%3Akind%2Fenhancement+-label%3Akind%2Fbug+-label%3Akind%
 2Fcleanup+-label%3Akind%2Fgraphics+-label%3Akind%2Fwriting+-label%3Akind%
 2Fsecurity+-label%3Akind%2Fquestion+-label%3Akind%2Fimprovement+-label%3Akind%
-2Ffeature" target="_blank">list of untriaged issues</a>.
+2Ffeature)
 
-4. Follow the <a
-href="https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md"
-target="_blank">the triage process</a> to triage the issue.
+4. Follow [the triage process](https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md) 
+to triage the issue.
 
 The triage process asks you to add both a `kind/` and a `exp/` label to each
 issue. Because you are not a Docker maintainer, you add these through comments.
@@ -86,7 +83,7 @@ Simply add a `+label` keyword to an issue comment:
 ![Example](../images/triage-label.png)
 
 For example, the `+exp/beginner` and `+kind/writing` labels would triage an issue as
-beginner writing task. For descriptions of valid labels, see the <a
-href="https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md">the triage process</a>
+beginner writing task. For descriptions of valid labels, see 
+[the triage process](https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md).
 
 5. Triage another issue.

--- a/docs/ways/test.md
+++ b/docs/ways/test.md
@@ -22,9 +22,10 @@ problems.
 
 # What can you contribute to testing?
 
-* Write a blog about <a href="http://www.appneta.com/blog/automated-testing-with-docker/" target="_blank">how your company uses Docker its test infrastructure</a>.  
-* Take <a href="http://ows.io/tj/w88v3siv" target="_blank">an online usability test</a> or create a usability test about Docker.
-* Test one of<a href="https://github.com/docker-library/official-images/issues"> Docker's official images</a>
+* Write a blog about 
+[how your company uses Docker's test infrastructure](https://www.appneta.com/blog/automated-testing-with-docker/).  
+* Take [an online usability test](http://ows.io/tj/w88v3siv) or create a usability test about Docker.
+* Test one of [Docker's official images](https://github.com/docker-library/official-images/issues)
 * Test the Docker documentation
 
 
@@ -32,14 +33,12 @@ problems.
 
 Testing documentation is relatively easy:
 
-## Step 1.  Find a page in <a href="http://docs.docker.com/" target="_blank">Docker's documentation</a> that contains a procedure or example you want to test.
+## Step 1.  Find a page in [Docker's documentation](https://docs.docker.com/) that contains a procedure or example you want to test.
 
 You should choose something that _should work_ on your machine. For example,
-<a href="http://docs.docker.com/articles/baseimages/" target="_blank">creating
-a base image</a> is something anyone with Docker can do. While <a
-href="https://kitematic.com/docs/managing-volumes/" target="_blank">changing
-volume directories in Kitematic</a> requires a Mac and Docker's Kitematic
-installed.
+[creating a base image](https://docs.docker.com/articles/baseimages) is something anyone with Docker can do. 
+While [changing volume directories in Kitematic](https://kitematic.com/docs/managing-volumes/) 
+requires a Mac and Docker's Kitematic installed.
 
 ## Step 2.  Try and follow the procedure or recreate the example.
 
@@ -49,10 +48,12 @@ What to look for:
  * Are the steps in the right order?
  * Did you get the results the procedure or example said you would?
 
-## Step 3.  If you couldn't complete the procedure or example, file <a href="https://github.com/docker/docker/issues/new" target="_blank">an issue in the Docker repo</a>.
+## Step 3.  If you couldn't complete the procedure or example, 
+file [an issue in the Docker repo](https://github.com/docker/docker/issues/new).
 
 # Test code in the Docker
 
-If you are interested in writing or fixing test code for the Docker project, learn  about  <a href="http://docs.docker.com/project/test-and-docs/" target="_blank">our test infrastructure</a>.
+If you are interested in writing or fixing test code for the Docker project, learn  about 
+[our test infrastructure](https://docs.docker.com/project/test-and-docs/).
 
-View <a href="http://goo.gl/EkyABb" target="_blank"> our open test issues</a> in Docker for something to work on. Or, create one of your own.
+View [our open test issues](https://goo.gl/EkyABb) in Docker for something to work on. Or, create one of your own.

--- a/docs/workflow/advanced-contributing.md
+++ b/docs/workflow/advanced-contributing.md
@@ -22,7 +22,7 @@ Your goal should be to understand the processes described.
 
 At this point, you should have read and worked through the earlier parts of
 the project contributor guide. You should also have
-<a href="../make-a-contribution/" target="_blank"> made at least one project contribution</a>.
+[made at least one project contribution](make-a-contribution.md).
 
 ## Refactor or cleanup proposal
 
@@ -72,13 +72,12 @@ The following provides greater detail on the process:
 
 2. Review existing issues and proposals to make sure no other user is proposing a similar idea.
 
-    The design proposals are <a
-    href="https://github.com/docker/docker/pulls?q=is%3Aopen+is%3Apr+label%
-    3Akind%2Fproposal" target="_blank">all online in our GitHub pull requests</a>.
+    The design proposals are [all online in our GitHub pull requests]
+    (https://github.com/docker/docker/pulls?q=is%3Aopen+is%3Apr+label%3Akind%2Fproposal).
 
 3. Talk to the community about your idea.
 
-    We have lots of <a href="../get-help/" target="_blank">community forums</a>
+    We have lots of [community forums](/opensource/get-help.md) 
     where you can get feedback on your idea. Float your idea in a forum or two
     to get some commentary going on it.
 
@@ -156,4 +155,5 @@ Making a pull request with a design proposal simplifies this process:
 * as a proposal changes and is updated, pages reset as line items resolve
 * GitHub maintains the entire history
 
-While proposals in pull requests do not end up merged into a master repository, they provide a convenient tool for managing the design process.
+While proposals in pull requests do not end up merged into a master repository, 
+they provide a convenient tool for managing the design process.

--- a/docs/workflow/coding-style.md
+++ b/docs/workflow/coding-style.md
@@ -52,14 +52,14 @@ program code and documentation code.
 
 * Use existing Docker test files (`name_test.go`) for inspiration.
 
-* Run <a href="../test-and-docs/" target="_blank">the full test suite</a> on your
+* Run [the full test suite](/opensource/project/test-and-docs.md) on your
   branch before submitting a pull request.
 
 * Run `make docs` to build the documentation and then check it locally.
 
-* Use an <a href="http://www.hemingwayapp.com" target="_blank">online grammar
-  checker</a> or similar to test you documentation changes for clarity,
-  concision, and correctness.
+* Use an [online grammar checker](http://www.hemingwayapp.com) 
+or similar to test you documentation changes for clarity, 
+concision, and correctness.
 
 ## Pull requests
 

--- a/docs/workflow/create-pr.md
+++ b/docs/workflow/create-pr.md
@@ -15,8 +15,8 @@ A pull request (PR) sends your changes to the Docker maintainers for review. You
 create a pull request on GitHub. A pull request "pulls" changes from your forked
 repository into the `docker/docker` repository.
 
-You can see <a href="https://github.com/docker/docker/pulls" target="_blank">the
-list of active pull requests to Docker</a> on GitHub.
+You can see [the list of active pull requests to Docker](https://github.com/docker/docker/pulls) 
+on GitHub.
 
 ## Check your work
 
@@ -84,7 +84,7 @@ Always rebase and squash your commits before making a pull request.
 
         $ git commit -s
 
-    Make sure your message includes <a href="/opensource/project/set-up-git/" target="_blank">your signature</a>.
+    Make sure your message includes [your signature](/opensource/project/set-up-git.md).
 
 7. Force push any changes to your fork on GitHub.
 

--- a/docs/workflow/find-an-issue.md
+++ b/docs/workflow/find-an-issue.md
@@ -94,8 +94,7 @@ master">exp/master</strong> level issue.
 
 To claim an issue:
 
-1. Go to the `docker/docker` <a
-	href="https://github.com/docker/docker" target="_blank">repository</a>.
+1. Go to the `docker/docker` [repository](https://github.com/docker/docker).
 
 2. Click the "Issues" link.
 

--- a/docs/workflow/review-pr.md
+++ b/docs/workflow/review-pr.md
@@ -115,7 +115,7 @@ It can take time to see a merged pull request in Docker's official release.
 A master build is available almost immediately though. Docker builds and
 updates its development binaries after each merge to `master`.
 
-1. Browse to <a href="https://master.dockerproject.org/" target="_blank">https://master.dockerproject.org/</a>.
+1. Browse to [https://master.dockerproject.org/](https://master.dockerproject.org/).
 
 2. Look for the binary appropriate to your system.
 
@@ -124,12 +124,11 @@ updates its development binaries after each merge to `master`.
     You might want to run the binary in a container though. This
     will keep your local host environment clean.
 
-4. View any documentation changes at <a href="http://docs.master.dockerproject.org/" target="_blank">docs.master.dockerproject.org</a>.
+4. View any documentation changes at [docs.master.dockerproject.org](http://docs.master.dockerproject.org/).
 
 Once you've verified everything merged, feel free to delete your feature branch
 from your fork. For information on how to do this,
-<a href="https://help.github.com/articles/deleting-unused-branches/" target="_blank">
-see the GitHub help on deleting branches</a>.  
+[see the GitHub help on deleting branches](https://help.github.com/articles/deleting-unused-branches/).  
 
 ## Where to go next
 

--- a/docs/workflow/work-issue.md
+++ b/docs/workflow/work-issue.md
@@ -26,9 +26,8 @@ Follow this workflow as you work:
 
 1. Review the appropriate style guide.
 
-    If you are changing code, review the <a href="../coding-style"
-    target="_blank">coding style guide</a>. Changing documentation? Review the
-    <a href="/opensource/doc-style/" target="_blank">documentation style guide</a>.
+    If you are changing code, review the [coding style guide](coding-style.md). 
+    Changing documentation? Review the [documentation style guide](/opensource/doc-style.md).
 
 2. Make changes in your feature branch.
 
@@ -38,18 +37,16 @@ Follow this workflow as you work:
     alone, you can work on your local host.
 
     Make sure you don't change files in the `vendor` directory and its
-    subdirectories; they contain third-party dependency code. Review <a
-    href="/opensource/project/set-up-dev-env/" target="_blank">if you forgot the details of
-    working with a container</a>.
+    subdirectories; they contain third-party dependency code. Review 
+    [if you forgot the details of working with a container](/opensource/project/set-up-dev-env.md).
 
 
 3. Test your changes as you work.
 
     If you have followed along with the guide, you know the `make test` target
     runs the entire test suite and `make docs` builds the documentation. If you
-    forgot the other test targets, see the documentation for <a
-    href="/opensource/project/test-and-docs/" target="_blank">testing both code and
-    documentation</a>.  
+    forgot the other test targets, see the documentation for 
+    [testing both code and documentation](/opensource/project/test-and-docs.md).  
 
 4. For code changes, add unit tests if appropriate.
 
@@ -131,7 +128,7 @@ Follow this workflow as you work:
 
 After you push a new branch, you should verify it on GitHub:
 
-1. Open your browser to <a href="https://github.com" target="_blank">GitHub</a>.
+1. Open your browser to [GitHub](https://github.com).
 
 2. Go to your Docker fork.
 
@@ -187,7 +184,7 @@ You should pull and rebase frequently as you work.
 
         $ git commit -s
 
-    Make sure your message includes <a href="/opensource/project/set-up-git/" target="_blank">your signature</a>.
+    Make sure your message includes [your signature](/opensource/project/set-up-git.md).
 
 7. Force push any changes to your fork on GitHub.
 


### PR DESCRIPTION
This PR updates all applicable links in opensource to markdown, per @SvenDowideit 's recommendation. Also changes some links to https, and fixes a few grammatical errors previously present in 'a' tags.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>

ping @moxiegirl @SvenDowideit 