### PR TITLE
Add Alumni rule

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -105,6 +105,18 @@ discussed with them among the other maintainers so that they are not surprised
 by a pull request removing them.
 """
 
+    [Rules.alumni]
+
+        title = "Alumni"
+
+        text = """
+Projects can opt to keep a list of former maintainers in the MAINTAINERS file.
+Instead of removing a maintainer from the file when they step down, the maintainer
+is moved to the alumni list (`[Org.Alumni]`). People on this list have
+no official capacity in the project, it's a way to say "thank you" for the
+work they have done for the project.
+"""
+
     [Rules.bdfl]
 
         title = "The Benevolent dictator for life (BDFL)"
@@ -487,7 +499,7 @@ or feedback about project operations.
         GitHub = "mavenugo"
     [People.mbentley]
         Name = "Matt Bentley"
-        Email = "mbentley@mbentley.net"
+        Email = "matt.bentley@docker.com"
         GitHub = "mbentley"
     [People.mchiang0610]
         Name = "Michael Chiang"

--- a/maintainercollector/rules.toml
+++ b/maintainercollector/rules.toml
@@ -93,6 +93,18 @@ discussed with them among the other maintainers so that they are not surprised
 by a pull request removing them.
 """
 
+    [Rules.alumni]
+
+        title = "Alumni"
+
+        text = """
+Projects can opt to keep a list of former maintainers in the MAINTAINERS file.
+Instead of removing a maintainer from the file when they step down, the maintainer
+is moved to the alumni list (`[Org.Alumni]`). People on this list have
+no official capacity in the project, it's a way to say "thank you" for the
+work they have done for the project.
+"""
+
     [Rules.bdfl]
 
         title = "The Benevolent dictator for life (BDFL)"


### PR DESCRIPTION
Projects can keep a list of former maintainers instead of removing them. This is something we discussed, but didn't add to the rules yet.