### PR TITLE
Initial Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,8 @@
+// Only run on Linux atm
+wrappedNode(label: 'linux') {
+  deleteDir()
+  stage "checkout"
+  checkout scm
+
+  documentationChecker("docs")
+}

--- a/docs/governance/board-profiles.md
+++ b/docs/governance/board-profiles.md
@@ -48,7 +48,7 @@ and community of the Docker Project.
 * Michael Crosby
 * Steve Francia
 * Stephen Day
-* Arnaud Poterie
+* Arnaud Porterie
 
 ## Individual Contributors
 
@@ -64,7 +64,7 @@ and community of the Docker Project.
 * Ahmet Alp Balkan (Microsoft)
 * Rohit Jnagal (Google)
 
-## User
+## Users
 
 * Nicola Paolucci (Atlassian)
 * Burke Libbey (Shopify)


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

we're going to move to Jenkinsfiles in each repo for both PR checkers and some auto-building to reduce the complexity of the Jenkins job configuration.

also
Closes #28 