### PR TITLE
Change command to build a development environment image

### DIFF
--- a/docs/project/set-up-dev-env.md
+++ b/docs/project/set-up-dev-env.md
@@ -125,7 +125,7 @@ can take over 15 minutes to complete.
 4. Use `make` to build a development environment image and run it in a container.
 
     ```bash
-    $ make shell
+    $ make BINDIR=. shell
     ```
 
     The command returns informational messages as it runs. The first build may

--- a/docs/project/set-up-dev-env.md
+++ b/docs/project/set-up-dev-env.md
@@ -125,7 +125,7 @@ can take over 15 minutes to complete.
 4. Use `make` to build a development environment image and run it in a container.
 
     ```bash
-    $ make BINDIR=. shell
+    $ make BIND_DIR=. shell
     ```
 
     The command returns informational messages as it runs. The first build may


### PR DESCRIPTION
> Use `make` to build a development environment image and run it in a container.
> 
> ```bash
> $ make BINDIR=. shell
> ```

Task 2, step 4 tells to use `make shell` to to build a development environment image and run it in a container. 

This does not mount the local Docker repository as needed and mentioned in Task 3.

In Task 3,
> Running the `make shell` command mounted your local Docker repository source into
> your Docker container. When you start to developing code though, you'll
> want to iterate code changes and builds inside the container.