### PR TITLE
Make sure the Docker source in bind mounted into the development container

### DIFF
--- a/docs/project/set-up-dev-env.md
+++ b/docs/project/set-up-dev-env.md
@@ -125,7 +125,7 @@ can take over 15 minutes to complete.
 4. Use `make` to build a development environment image and run it in a container.
 
     ```bash
-    $ make shell
+    $ make BIND_DIR=. shell
     ```
 
     The command returns informational messages as it runs. The first build may


### PR DESCRIPTION
In "Task 2. Start a development container" make sure the Docker source
code is bind mounted into the development container. Otherwise in Task 3
changes made to the source code outside the container will not be
visible inside the container.

This is basically the change made by @mbtamuli in #84 but that change
seems to have been abandoned.

Signed-off-by: Dan Liew <daniel.liew@imperial.ac.uk>