### PR TITLE
Update Linux Foundation contact information

### DIFF
--- a/project-template/CONTRIBUTING.md
+++ b/project-template/CONTRIBUTING.md
@@ -27,11 +27,13 @@ Developer Certificate of Origin
 Version 1.1
 
 Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-660 York Street, Suite 102,
-San Francisco, CA 94110 USA
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
 
 Everyone is permitted to copy and distribute verbatim copies of this
 license document, but changing it is not allowed.
+
 
 Developer's Certificate of Origin 1.1
 


### PR DESCRIPTION
They moved, so updating the information to
match the one at http://developercertificate.org
