### PR TITLE
project-template/README: Cleanup licensing (BY-SA link, etc.)

### DIFF
--- a/project-template/README.md
+++ b/project-template/README.md
@@ -19,8 +19,10 @@ ruling it out in the future.
 ## Copyright and license
 
 Copyright © 2015 Docker, Inc. All rights reserved, except as follows. Code
-is released under the Apache 2.0 license. The README.md file, and files in the
-"docs" folder are licensed under the Creative Commons Attribution 4.0
+is released under the [Apache 2.0 license](LICENSE.code). This `README.md`
+file, the [`CONTRIBUTING.md`](CONTRIBUTING.md) file, and files in the
+`docs` folder are licensed under the Creative Commons Attribution 4.0
 International License under the terms and conditions set forth in the file
-"LICENSE.docs". You may obtain a duplicate copy of the same license, titled
-CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.
+[`LICENSE.docs`](LICENSE.docs). You may obtain a duplicate copy of the
+same license, titled CC BY-SA 4.0, at
+http://creativecommons.org/licenses/by-sa/4.0/.


### PR DESCRIPTION
LICENSE.docs has had the BY-SA copy since fcff91e6 (Add project template, 2015-12-21).

Also:

* Make file references links for convenient access.
* Explicitly put `CONTRIBUTING.md` under the docs license.
* Use backticks for paths (less clutter than quotes in the rendered view).
* Use the canonical abbreviation (CC BY-SA 4.0) instead of CC-BY-SA-4.0.