### PR TITLE
fix parsing of maintainers file

### DIFF
--- a/maintainercollector/main.go
+++ b/maintainercollector/main.go
@@ -91,13 +91,19 @@ func main() {
 			continue
 		}
 
-		// create the Org object for the project
-		p := &Org{
-			// Repo: fmt.Sprintf("https://github.com/%s/%s", org, project),
-			// TODO: change this to:
-			// People: maintainers.Org["Core maintainers"].People,
-			// once MaintainersDepreciated is removed.
-			People: maintainers.Organization.CoreMaintainers.People,
+		p := &Org{}
+		if maintainers.Organization.Maintainers != nil {
+			p.People = maintainers.Organization.Maintainers.People
+		} else if maintainers.Organization.CoreMaintainers != nil {
+			// create the Org object for the project
+			p.People = maintainers.Organization.CoreMaintainers.People
+			//p := &Org{
+			//	// Repo: fmt.Sprintf("https://github.com/%s/%s", org, project),
+			//	// TODO: change this to:
+			//	// People: maintainers.Org["Core maintainers"].People,
+			//	// once MaintainersDepreciated is removed.
+			//	People: maintainers.Organization.CoreMaintainers.People,
+			//}
 		}
 
 		// lowercase all maintainers nicks for consistency
@@ -157,6 +163,9 @@ func removeDuplicates(slice []string) []string {
 
 func getMaintainers(project string) (maintainers MaintainersDepreciated, err error) {
 	fileUrl := fmt.Sprintf("%s/%s/%s/master/MAINTAINERS", ghRawUri, org, project)
+
+	logrus.Infof("%s: loading MAINTAINERS file from %v", project, fileUrl)
+
 	resp, err := http.Get(fileUrl)
 	if err != nil {
 		return maintainers, fmt.Errorf("%s: %v", project, err)

--- a/maintainercollector/types.go
+++ b/maintainercollector/types.go
@@ -49,6 +49,7 @@ type Organization struct {
 	ChiefMaintainer  string `toml:"Chief Maintainer"`
 	CommunityManager string `toml:"Community Manager"`
 	CoreMaintainers  *Org   `toml:"Core maintainers"`
+	Maintainers      *Org   `toml:"Maintainers"`
 	DocsMaintainers  *Org   `toml:"Docs maintainers"`
 	Curators         *Org   `toml:"Curators"`
 }


### PR DESCRIPTION
MAINTAINERS files can have the maintainers
listed either under "Org.Core Maintainers", or
"Org.Maintainers". This fixes parsing of both
variations.
