### PR TITLE
Use containerd/containerd instead of the forked repo

### DIFF
--- a/maintainercollector/main.go
+++ b/maintainercollector/main.go
@@ -35,7 +35,7 @@ var (
 		"boot2docker",
 		"cli",
 		"compose",
-		"containerd",
+		"containerd/containerd",
 		"distribution",
 		"docker-bench-security",
 		"docker-credential-helpers",


### PR DESCRIPTION
containerd/containerd is now the main repository, and the docker/containerd is a fork.
